### PR TITLE
feat: sync audiobookshelf with stage2 repo

### DIFF
--- a/clusters/staging/flux-system/gotk-sync.yaml
+++ b/clusters/staging/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: audiobookshelf
+    branch: feat/audiobookshelf-stage2
   secretRef:
     name: flux-system
   url: ssh://git@github.com/milanoid/homelab-cluster


### PR DESCRIPTION
# Stage 2

- Add persistent volumes for all of the suggested volumes in the Audiobookshelf documentation.
- Audiobooks and configuration should persist when you restart the pod.

Suggested volumes as per https://www.audiobookshelf.org/docs#docker-compose-upgrade

1. `/config`
2. `/metadata`
3. `/audiobooks`
4. `/books`
5. `/podcasts`