### PR TITLE
fix(flux): update GitRepository URL to milanoid-labs org

### DIFF
--- a/clusters/staging/flux-system/gotk-sync.yaml
+++ b/clusters/staging/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: ssh://git@github.com/milanoid/homelab-cluster
+  url: ssh://git@github.com/milanoid-labs/homelab-cluster
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- Repo moved from `github.com/milanoid/homelab-cluster` to `github.com/milanoid-labs/homelab-cluster`
- Update Flux `GitRepository` source URL in `clusters/staging/flux-system/gotk-sync.yaml` so reconciliation targets the new remote

Repo-wide grep confirmed this was the only stale GitHub reference; arc-runners and renovate config already use `milanoid-labs`.

## Test plan
- [ ] After merge: `flux get sources git -A` shows `flux-system` reconciling cleanly against the new URL
- [ ] `flux get kustomizations` all Ready
- [ ] If pull fails, recreate the `flux-system` SSH deploy key secret against the new repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)