### PR TITLE
fix: disable ArgoCD server TLS for Traefik compatibility

### DIFF
--- a/infrastructure/controllers/base/argocd/release.yaml
+++ b/infrastructure/controllers/base/argocd/release.yaml
@@ -25,6 +25,7 @@ spec:
     dex:
       enabled: false
     server:
+      insecure: true
       ingress:
         enabled: true
         ingressClassName: traefik


### PR DESCRIPTION
## Summary

- ArgoCD serves HTTPS by default with a self-signed cert. Traefik cannot verify this cert when proxying, causing `500 Internal Server Error` (`x509: cannot validate certificate for IP because it doesn't contain any IP SANs`)
- Setting `server.insecure: true` makes ArgoCD serve HTTP internally, letting Traefik proxy correctly

## Test plan

- [ ] Access `http://argocd.milanoid.net` — should load the ArgoCD UI without 500 errors
- [ ] Check Traefik logs for no more TLS errors: `kubectl logs -n kube-system traefik-c98fdf6fb-hdtkk -c traefik --tail=20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)