### PR TITLE
fix: use correct helm value path for ArgoCD insecure mode

### DIFF
--- a/infrastructure/controllers/base/argocd/release.yaml
+++ b/infrastructure/controllers/base/argocd/release.yaml
@@ -22,10 +22,12 @@ spec:
   driftDetection:
     mode: enabled
   values:
+    configs:
+      params:
+        server.insecure: true
     dex:
       enabled: false
     server:
-      insecure: true
       ingress:
         enabled: true
         ingressClassName: traefik


### PR DESCRIPTION
## Summary

- `server.insecure` is deprecated in argo-cd chart v9.x — it wasn't taking effect, causing Traefik 500 errors
- Moved to `configs.params.server.insecure: true` which writes to the `argocd-cmd-params-cm` ConfigMap and passes `--insecure` to the server

## Test plan

- [ ] Flux reconciles: `flux get helmreleases -n argocd`
- [ ] ArgoCD UI loads at `http://argocd.milanoid.net`
- [ ] No more TLS errors in Traefik logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)