### PR TITLE
feat: add guestbook demo app with ArgoCD app-of-apps pattern

### DIFF
--- a/apps/argocd/app-of-apps.yaml
+++ b/apps/argocd/app-of-apps.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: app-of-apps
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/apps/argocd/app-of-apps.yaml
+++ b/apps/argocd/app-of-apps.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/milanoid-labs/homelab-cluster.git
+    targetRevision: HEAD
+    path: apps/argocd
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/apps/argocd/guestbook.yaml
+++ b/apps/argocd/guestbook.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: guestbook
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/apps/argocd/guestbook.yaml
+++ b/apps/argocd/guestbook.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: guestbook
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Add **app-of-apps** root Application that watches `apps/argocd/` for child Application CRs — fully GitOps, future apps are just a commit away
- Add **guestbook** demo app pointing at upstream `argoproj/argocd-example-apps` with automated sync and self-heal
- Remove `.gitkeep` placeholder

## After merge

One-time bootstrap (only needed once):
```bash
kubectl apply -f apps/argocd/app-of-apps.yaml
```

Then verify at http://argocd.milanoid.net — should show `app-of-apps` and `guestbook`.

## Test plan
- [x] Merge PR
- [x] Bootstrap: `kubectl apply -f apps/argocd/app-of-apps.yaml`
- [x] Verify `kubectl get applications -n argocd` shows both apps
- [x] Verify `kubectl get pods -n guestbook` shows guestbook pods running
- [ ] Check ArgoCD UI shows both apps healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)