### PR TITLE
test: scale guestbook to 3 replicas

### DIFF
--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: guestbook-ui
 spec:
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
- Change guestbook replicas from 1 to 3 to test ArgoCD sync

## Test plan
- [ ] Merge PR
- [ ] Watch ArgoCD UI at http://argocd.milanoid.net — guestbook app should go OutOfSync then auto-sync
- [ ] Verify `kubectl get pods -n guestbook` shows 3 pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)