### PR TITLE
test: use non-existent image tag to trigger sync failure

### DIFF
--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:v5@sha256:a908df8486ff66f2c4daa0d3d8a2fa09846a1fc8efd65649c0109695c7c5cbff
+        - image: gcr.io/google-samples/gb-frontend:does-not-exist
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
## Summary
- Set guestbook image to `gb-frontend:does-not-exist` to test ArgoCD's behavior on deployment failure

## What to observe
After merge, ArgoCD will:
1. Sync the new manifest (sync succeeds)
2. Pods enter `ImagePullBackOff` / `ErrImagePull`
3. App health shows **Degraded** in the UI

This tests ArgoCD's error reporting — the sync itself works, but the app is unhealthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)