### PR TITLE
Fix guestbook ImagePullBackOff - restore valid image tag

### DIFF
--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:does-not-exist
+        - image: gcr.io/google-samples/gb-frontend:v5
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
Fixes the `ImagePullBackOff` on `guestbook-ui` caused by an invalid image tag `does-not-exist`. Restores it to `v5` which is confirmed working (currently running on the 3 healthy pods).