### PR TITLE
test: invalid containerPort 99999 to trigger ArgoCD sync failure

### DIFF
--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         - image: gcr.io/google-samples/gb-frontend:v5
           name: guestbook-ui
           ports:
-            - containerPort: 80
+            - containerPort: 99999

--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:does-not-exist
+        - image: gcr.io/google-samples/gb-frontend:v5
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
## Purpose

Test PR to demonstrate that `argocd app sync` exits non-zero when Kubernetes rejects a manifest.

## Change

Sets `containerPort: 99999` in `guestbook/deployment.yaml` — Kubernetes port range is 1–65535, so the API server will reject the manifest and `argocd app sync` will fail.

## Test Plan

After merging, wait for Flux to sync (`app-of-apps`) then run:

```bash
argocd app sync argocd/guestbook --grpc-web
echo "Exit code: $?"

argocd app get argocd/guestbook --grpc-web
```

Expected: non-zero exit code, `OutOfSync`/`Degraded` state with validation error.

## Cleanup

Follow-up PR will revert `containerPort` back to `80`.