### PR TITLE
Revert "test: invalid containerPort 99999 to trigger ArgoCD sync failure"

### DIFF
--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         - image: gcr.io/google-samples/gb-frontend:v5
           name: guestbook-ui
           ports:
-            - containerPort: 99999
+            - containerPort: 80


### PR DESCRIPTION
Reverts milanoid-labs/homelab-cluster#180