### PR TITLE
test: bump guestbook replicas from 3 to 5

### DIFF
--- a/apps/argocd/guestbook.yaml
+++ b/apps/argocd/guestbook.yaml
@@ -4,8 +4,6 @@ kind: Application
 metadata:
   name: guestbook
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/apps/argocd/guestbook.yaml
+++ b/apps/argocd/guestbook.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: guestbook
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: guestbook-ui
 spec:
-  replicas: 3
+  replicas: 5
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/apps/argocd/guestbook/deployment.yaml
+++ b/apps/argocd/guestbook/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         - image: gcr.io/google-samples/gb-frontend:v5
           name: guestbook-ui
           ports:
-            - containerPort: 80
+            - containerPort: 80000 # test argocd diff


### PR DESCRIPTION
Bumps guestbook replicas from 3 to 5 to test `argocd app diff` without the `--local` flag.