### PR TITLE
feat(argocd): enable automated sync (v3.x)

### DIFF
--- a/apps/argocd/app-of-apps.yaml
+++ b/apps/argocd/app-of-apps.yaml
@@ -17,5 +17,6 @@ spec:
     namespace: argocd
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true

--- a/apps/argocd/guestbook.yaml
+++ b/apps/argocd/guestbook.yaml
@@ -17,6 +17,7 @@ spec:
     namespace: guestbook
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:


### PR DESCRIPTION
## Summary

- Add `enabled: true` under `syncPolicy.automated` in both ArgoCD Application manifests
- Fixes "Auto sync is not enabled" shown in ArgoCD v3.3.6 UI
- ArgoCD v3.1.0 introduced this explicit field; without it autosync is inactive even when `prune`/`selfHeal` are set

## Affected files

- `apps/argocd/app-of-apps.yaml`
- `apps/argocd/guestbook.yaml`

## After merging

Run once to bootstrap (cluster won't auto-apply until autosync is active):
```bash
argocd app sync app-of-apps
```

## Test plan

- [x] Merge PR
- [ ] Run `argocd app sync app-of-apps`
- [ ] Verify `argocd app get app-of-apps` shows `AutoSync: Enabled`
- [ ] Verify `argocd app get guestbook` shows `AutoSync: Enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)