### PR TITLE
feat(ci): add copilot-setup-steps workflow for ARC self-hosted runners

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,13 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: homelab-runners
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: homelab-runners
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: '20'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,6 +3,9 @@ name: Copilot Setup Steps
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: homelab-runners


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/copilot-setup-steps.yml` to enable GitHub Copilot code review on self-hosted ARC runners
- Points Copilot at the existing `homelab-runners` scale set (Ubuntu x64, 1–10 runners)
- No changes to ARC HelmRelease, Flux kustomizations, or secrets

## Pre-requisite (manual)

Verify Copilot code review is enabled: **GitHub → milanoid-labs org → Settings → Copilot → Policies**

## Test plan

- [ ] Merge this PR
- [ ] Open a test PR and request a Copilot review
- [ ] Confirm `copilot-setup-steps` job runs on `homelab-runners`
- [ ] Confirm Copilot posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)