### PR TITLE
fix(ci): install gh CLI in copilot-setup-steps for self-hosted runners

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,15 @@ jobs:
   copilot-setup-steps:
     runs-on: homelab-runners
     steps:
+      - name: Install GitHub CLI
+        run: |
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:


### PR DESCRIPTION
## Summary

- Adds a step to install the GitHub CLI (`gh`) before Copilot code review runs
- The base `actions-runner` image is minimal and doesn't ship `gh` — Copilot requires it internally
- Uses the official GitHub apt repository for installation

## Test plan

- [ ] Merge and trigger a Copilot code review on a PR
- [ ] Confirm `copilot-setup-steps` job completes without `gh: command not found`

Fixes error from run: https://github.com/milanoid-labs/homelab-cluster/actions/runs/24523840059/job/71688639857

🤖 Generated with [Claude Code](https://claude.com/claude-code)