### PR TITLE
feat(runner): add custom runner image with gh CLI pre-installed

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -1,0 +1,41 @@
+name: Build Runner Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'runner/Dockerfile'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: homelab-runners
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/milanoid-labs/homelab-runner
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: runner
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/actions/actions-runner:2.333.1@sha256:b57864c9fcda15ea4a270446aa9cfb108b819a26f6e71fc515f6caf6c27989c6
+
+USER root
+RUN apt-get update \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+         https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] \
+         https://cli.github.com/packages stable main" \
+         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+USER runner


### PR DESCRIPTION
## Summary

- Adds `runner/Dockerfile` extending the official `actions-runner` image with `gh` CLI pre-installed (required for Copilot code review)
- Adds `build-runner-image.yml` workflow that builds and pushes `ghcr.io/milanoid-labs/homelab-runner` to GHCR on every `runner/Dockerfile` change
- Image is tagged with git short SHA (immutable reference) + `latest`
- Build runs on `homelab-runners` using the dind sidecar for Docker

## After merging

1. The `Build Runner Image` workflow will run automatically
2. **Manual step:** Go to [org packages](https://github.com/orgs/milanoid-labs/packages) → `homelab-runner` → Package Settings → set visibility to **Public** (so ARC pods can pull without imagePullSecrets)
3. Follow-up PR will update the ARC HelmRelease to use this image

## Test plan

- [ ] Merge → confirm `Build Runner Image` workflow succeeds on `homelab-runners`
- [ ] Confirm image appears at `ghcr.io/milanoid-labs/homelab-runner` with SHA and `latest` tags
- [ ] Make package public

🤖 Generated with [Claude Code](https://claude.com/claude-code)