### PR TITLE
fix(runner): use curl instead of wget to install gh CLI

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -2,9 +2,10 @@ FROM ghcr.io/actions/actions-runner:2.333.1@sha256:b57864c9fcda15ea4a270446aa9cf
 
 USER root
 RUN apt-get update \
+    && apt-get install -y curl \
     && mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -qO /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-         https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] \
          https://cli.github.com/packages stable main" \


### PR DESCRIPTION
## Summary

- `wget` is not present in the base `actions-runner` image, causing exit code 127 during Docker build
- Switch to `curl` (explicitly installed first via `apt-get`) to download the GitHub CLI signing key

Fixes: https://github.com/milanoid-labs/homelab-cluster/actions/runs/24525047645/job/71692905388

🤖 Generated with [Claude Code](https://claude.com/claude-code)