### PR TITLE
feat(arc): use custom homelab-runner image with gh CLI

### DIFF
--- a/infrastructure/controllers/base/arc-runners/release.yaml
+++ b/infrastructure/controllers/base/arc-runners/release.yaml
@@ -30,15 +30,14 @@ spec:
       spec:
         initContainers:
           - name: init-dind-externals
-            image: ghcr.io/milanoid-labs/homelab-runner:latest
+            image: ghcr.io/milanoid-labs/homelab-runner:8855aaf
             command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
             volumeMounts:
               - name: dind-externals
                 mountPath: /home/runner/tmpDir
         containers:
           - name: runner
-            image: ghcr.io/milanoid-labs/homelab-runner:latest
-            imagePullPolicy: Always
+            image: ghcr.io/milanoid-labs/homelab-runner:8855aaf
             command: ["/home/runner/run.sh"]
             env:
               - name: DOCKER_HOST

--- a/infrastructure/controllers/base/arc-runners/release.yaml
+++ b/infrastructure/controllers/base/arc-runners/release.yaml
@@ -30,14 +30,15 @@ spec:
       spec:
         initContainers:
           - name: init-dind-externals
-            image: ghcr.io/actions/actions-runner:2.333.1@sha256:b57864c9fcda15ea4a270446aa9cfb108b819a26f6e71fc515f6caf6c27989c6
+            image: ghcr.io/milanoid-labs/homelab-runner:latest
             command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
             volumeMounts:
               - name: dind-externals
                 mountPath: /home/runner/tmpDir
         containers:
           - name: runner
-            image: ghcr.io/actions/actions-runner:2.333.1@sha256:b57864c9fcda15ea4a270446aa9cfb108b819a26f6e71fc515f6caf6c27989c6
+            image: ghcr.io/milanoid-labs/homelab-runner:latest
+            imagePullPolicy: Always
             command: ["/home/runner/run.sh"]
             env:
               - name: DOCKER_HOST


### PR DESCRIPTION
## Summary

- Updates ARC HelmRelease to use `ghcr.io/milanoid-labs/homelab-runner:latest` for both the `runner` container and `init-dind-externals` initContainer
- Adds `imagePullPolicy: Always` to the runner container so new image versions are picked up on pod restart
- Custom image has `gh` CLI pre-installed — required for Copilot code review

## Pre-requisites

- [x] `ghcr.io/milanoid-labs/homelab-runner:latest` built and pushed (PR #193)
- [x] Package set to public on GHCR

## Test plan

- [ ] Merge → Flux reconciles HelmRelease → ARC runner pods restart
- [ ] `kubectl -n arc-runners get pods` — verify pods running with new image
- [ ] Trigger a Copilot code review on a test PR — confirm no `gh: command not found` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)