### PR TITLE
feat(argocd): set timeout.reconciliation explicitly to 180s

### DIFF
--- a/infrastructure/controllers/base/argocd/release.yaml
+++ b/infrastructure/controllers/base/argocd/release.yaml
@@ -23,6 +23,8 @@ spec:
     mode: enabled
   values:
     configs:
+      cm:
+        timeout.reconciliation: 180s
       params:
         server.insecure: true
     dex:


### PR DESCRIPTION
## Summary

- Adds `configs.cm.timeout.reconciliation: 180s` to the ArgoCD HelmRelease values
- Makes the default Git sync interval explicit rather than relying on the ArgoCD built-in default

## Verification

After Flux reconciles the HelmRelease:
```
kubectl get cm argocd-cm -n argocd -o yaml | grep timeout.reconciliation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)