### PR TITLE
feat(argocd): add guestbook health badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ With Flux CD, managing the cluster and deploying applications is driven by git c
 
 ArgoCD is deployed for testing/evaluation alongside Flux. By convention, it is used for apps under `apps/argocd/`; this README does not imply an enforced isolation boundary from Flux-managed resources. UI available at `argocd.milanoid.net` (LAN/VPN).
 
+Guestbook app health (visible from LAN/VPN only — external viewers will see a broken image):
+
+[![Guestbook status](https://argocd.milanoid.net/api/badge?name=guestbook&showAppName=true&revision=true)](https://argocd.milanoid.net/applications/guestbook)
+
 ### Hosted apps
 
 - Linkding (bookmark manager) https://lkd.milanoid.net/

--- a/infrastructure/controllers/base/argocd/release.yaml
+++ b/infrastructure/controllers/base/argocd/release.yaml
@@ -25,6 +25,7 @@ spec:
     configs:
       cm:
         timeout.reconciliation: 180s
+        statusbadge.enabled: "true"
       params:
         server.insecure: true
     dex:


### PR DESCRIPTION
## Summary

- Enable the ArgoCD status-badge endpoint by setting `statusbadge.enabled: "true"` in `argocd-cm` (via the HelmRelease values).
- Embed a live health/sync badge for the `guestbook` Application in the root `README.md`, linking to the app page in the ArgoCD UI.

The badge feature is disabled by default because `/api/badge` is served without authentication. Since `argocd.milanoid.net` is LAN/VPN-only, the badge will only render for on-network readers — this is called out inline in the README so the broken image on public GitHub is self-explanatory.

## Test plan

- [ ] Merge and wait for Flux reconciliation (or force: `flux reconcile helmrelease argocd -n argocd`)
- [ ] Confirm ConfigMap carries the flag: `kubectl -n argocd get cm argocd-cm -o jsonpath='{.data.statusbadge\.enabled}'` → `true`
- [ ] From LAN/VPN: `curl -sI "https://argocd.milanoid.net/api/badge?name=guestbook&showAppName=true&revision=true"` → `200 OK`, `image/svg+xml`
- [ ] Open the repo on github.com while on VPN — badge renders; off-VPN it shows broken image as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)