### PR TITLE
feat(argocd): expose /api/badge publicly via path-scoped Cloudflare tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ With Flux CD, managing the cluster and deploying applications is driven by git c
 
 ArgoCD is deployed for testing/evaluation alongside Flux. By convention, it is used for apps under `apps/argocd/`; this README does not imply an enforced isolation boundary from Flux-managed resources. UI available at `argocd.milanoid.net` (LAN/VPN).
 
-Guestbook app health (visible from LAN/VPN only — external viewers will see a broken image):
+Guestbook app health:
 
-[![Guestbook status](https://argocd.milanoid.net/api/badge?name=guestbook&showAppName=true&revision=true)](https://argocd.milanoid.net/applications/guestbook)
+[![Guestbook status](https://argocd-badge.milanoid.net/api/badge?name=guestbook&showAppName=true&revision=true)](https://argocd.milanoid.net/applications/guestbook)
 
 ### Hosted apps
 

--- a/infrastructure/controllers/staging/argocd/cloudflare.yaml
+++ b/infrastructure/controllers/staging/argocd/cloudflare.yaml
@@ -16,6 +16,11 @@ spec:
       containers:
         - name: cloudflared
           image: cloudflare/cloudflared:2026.3.0@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
             - tunnel
             - --config

--- a/infrastructure/controllers/staging/argocd/cloudflare.yaml
+++ b/infrastructure/controllers/staging/argocd/cloudflare.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-badge
+spec:
+  selector:
+    matchLabels:
+      app: cloudflared-badge
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cloudflared-badge
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:2026.3.0@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0
+          args:
+            - tunnel
+            - --config
+            - /etc/cloudflared/config/config.yaml
+            - run
+          ports:
+            - containerPort: 2000
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cloudflared/config
+              readOnly: true
+            - name: creds
+              mountPath: /etc/cloudflared/creds
+              readOnly: true
+      volumes:
+        - name: creds
+          secret:
+            secretName: argocd-badge-tunnel-credentials
+        - name: config
+          configMap:
+            name: cloudflared-badge
+            items:
+              - key: config.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflared-badge
+data:
+  config.yaml: |
+    tunnel: argocd-badge
+    credentials-file: /etc/cloudflared/creds/credentials.json
+
+    metrics: 0.0.0.0:2000
+    no-autoupdate: true
+
+    ingress:
+      - hostname: argocd-badge.milanoid.net
+        path: ^/api/badge(/.*)?$
+        service: http://argocd-server:80
+      - hostname: argocd-badge.milanoid.net
+        service: http_status:404
+      - service: http_status:404

--- a/infrastructure/controllers/staging/argocd/kustomization.yaml
+++ b/infrastructure/controllers/staging/argocd/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: argocd
 resources:
   - ../../base/argocd/
+  - cloudflare.yaml
+  - tunnel-credentials.yaml

--- a/infrastructure/controllers/staging/argocd/tunnel-credentials.yaml
+++ b/infrastructure/controllers/staging/argocd/tunnel-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    credentials.json: ENC[AES256_GCM,data:X08zttiWha13dHnYsIaaMyoGaL8lbsiFS64mjnSWrzH3Xjz4GCvSRwl8RoMGnIQDXIWtFF1rrme7AEsSBMgUeAsx8eUNWqbUoj/Dr+bz+khIFL3CLqfrV0P44z7QL/tm57cVuqHi7H3NpDZ5va6IZkSIoxqiUcYM5Kj6S1DiU1Nd+C0JTsvkG+64Hg7YSndRQBpimd0acBai9P4mJ0NX3ltLN03uNzLW4VBytfnRJPXX02Qz9qgRqKEcgYl2ynyKX2HW9kL+SvWJo4SXs6rJcVlK/qjo3jxdrhWhxsy/D0TE92MQfq0aokVfkfs=,iv:sJItSm35TNdTWDrn6DNRRiIuzuC4RJ68T72b1G+gGjk=,tag:IC7Zlu5H7MA/brTTUmcX/Q==,type:str]
+kind: Secret
+metadata:
+    name: argocd-badge-tunnel-credentials
+    namespace: argocd
+sops:
+    age:
+        - recipient: age1jnfhet7cj900tg9f0dwgqktjwux4km4hen8gnevpujm5260sayesujm92y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWSjFZemlvemc0ekR3RDNL
+            YjJlejNreU5HTDZkVzY2WmQ0amlBYjBIYm5nCmJaQlhtT1NieENjUXg2S2ZtNFVw
+            UGs1VlNaNEJkRFZ2NXFJcVFIdWg2WkEKLS0tIGJwbkxGY2FINlpCblpWTFB5WmE3
+            bUtRNUhER3VLVUNKSS82VkszT0p1c2cK/VN2S2dvMrnDdjzRZcGQfMej6LywNaPZ
+            MpAq/TFbwAooQ5gd6LE28Nxtk1nDJtTZlWnvTIXMHwQiJTfnCJaeFg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-17T07:26:39Z"
+    mac: ENC[AES256_GCM,data:58J2o5PjveTOSq5ufmKD0YQn7LFWU1MjjllmXxpxx0CyJTuMHEXBpqtqukkPRqBzsDHXXjZ8zKp5vWeSxdFiLS11d02KkdjefcAMhNPzXVfOgp+ML2wm1mtU3qhDaLzeza2OZPVso2/+EmGl+hClBBMJ3Tr84adtVhUoGCvY9UQ=,iv:gvgUaGIBlyihKQdv3qSn8ILYI2yEIE7ODBE7Y7gHCjU=,tag:Jltiz9VmHT7Av8HhNRoPHA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2


### PR DESCRIPTION
## Summary

- New `cloudflared-badge` Deployment + ConfigMap in the `argocd` namespace that publishes `argocd-badge.milanoid.net` via a dedicated Cloudflare Tunnel.
- Tunnel `ingress` rules path-scope public traffic to **only** `^/api/badge(/.*)?$` → `http://argocd-server:80`. Every other path on the hostname terminates at cloudflared with `http_status:404` and never reaches ArgoCD.
- README badge URL swapped from `argocd.milanoid.net` (LAN/VPN) to `argocd-badge.milanoid.net` (public) so GitHub's image proxy can render it.
- Runs **1 replica** (badge is non-critical, Cloudflare caches successful responses).
- `argocd.milanoid.net` Traefik ingress is untouched — UI/API/login stay internal.

## Security posture

- Only `/api/badge*` is reachable from the internet; all other endpoints return 404 at the edge.
- ArgoCD's `/api/badge` is unauthenticated by design (gated behind `statusbadge.enabled`, enabled in #199).
- Dedicated tunnel + credentials; not shared with linkding/audiobookshelf/webhosting tunnels.
- Accepted trade-off: anyone on the internet can query app status/sync/revision by name. The repo is public, so this adds little info disclosure.

## Stacking

This PR targets `feat/argocd-guestbook-badge` (#199), which enables `statusbadge.enabled` in `argocd-cm`. Merge #199 first, then rebase this onto `main`.

## ⚠️ Do not merge until the tunnel secret is committed

`cloudflared-badge` will crash-loop without the `argocd-badge-tunnel-credentials` Secret. Run the CLI flow below, then commit the resulting SOPS-encrypted file onto this branch.

```bash
# 0. One-time: install cloudflared locally if needed
#    brew install cloudflared

# 1. Authenticate cloudflared against the Cloudflare account (opens a browser)
cloudflared tunnel login

# 2. Create the tunnel. Writes ~/.cloudflared/<UUID>.json and registers
#    the tunnel "argocd-badge" in Cloudflare.
cloudflared tunnel create argocd-badge

# 3. Create the DNS CNAME: argocd-badge.milanoid.net -> <UUID>.cfargotunnel.com
cloudflared tunnel route dns argocd-badge argocd-badge.milanoid.net

# 4. Capture the tunnel UUID
TUNNEL_UUID=$(cloudflared tunnel list -o json | jq -r '.[] | select(.name=="argocd-badge") | .id')

# 5. Build the SOPS-encrypted Secret manifest
kubectl create secret generic argocd-badge-tunnel-credentials \
  -n argocd \
  --from-file=credentials.json=$HOME/.cloudflared/${TUNNEL_UUID}.json \
  --dry-run=client -o yaml \
  > infrastructure/controllers/staging/argocd/tunnel-credentials.yaml

sops --encrypt --in-place infrastructure/controllers/staging/argocd/tunnel-credentials.yaml

# 6. Commit and push
git add infrastructure/controllers/staging/argocd/tunnel-credentials.yaml
git commit -m "feat(argocd): add SOPS-encrypted tunnel credentials for argocd-badge"
git push
```

## Test plan

- [x] Run the CLI flow above; confirm `cloudflared tunnel list | grep argocd-badge` shows the tunnel
- [ ] After merge + Flux reconcile: `kubectl -n argocd logs deploy/cloudflared-badge --tail=50 | grep -i "registered tunnel connection"` → 2 connections (1 replica × 2 CF edge)
- [ ] `curl -sI "https://argocd-badge.milanoid.net/api/badge?name=guestbook&showAppName=true&revision=true"` → **200**, `image/svg+xml`
- [ ] `curl -sI "https://argocd-badge.milanoid.net/"` → **404**
- [ ] `curl -sI "https://argocd-badge.milanoid.net/login"` → **404**
- [ ] `curl -sI "https://argocd-badge.milanoid.net/api/v1/session"` → **404**
- [ ] `curl -sI "https://argocd-badge.milanoid.net/api/badgex"` → **404** (regex boundary)
- [ ] From LAN/VPN: `curl -sI "https://argocd.milanoid.net/"` → still 200/302 (internal access unchanged)
- [ ] README badge renders on github.com from an off-VPN browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)