### PR TITLE
feat(homarr): add Homarr dashboard (LAN/VPN only)

### DIFF
--- a/apps/base/homarr/deployment.yaml
+++ b/apps/base/homarr/deployment.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homarr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homarr
+  template:
+    metadata:
+      labels:
+        app: homarr
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: hpmini02  # pinned: local-path PV lives on this node
+      containers:
+        - name: homarr
+          image: ghcr.io/homarr-labs/homarr:v1.59.1@sha256:655b4503c8c088873c6c4ed3e7e2e10052ff8a7199b41cdd5bac1bd21596613b
+          ports:
+            - containerPort: 7575
+          envFrom:
+            - secretRef:
+                name: homarr-secrets
+          volumeMounts:
+            - mountPath: /appdata
+              name: homarr-data
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0  # image ships root-owned /appdata and runs as root
+      volumes:
+        - name: homarr-data
+          persistentVolumeClaim:
+            claimName: homarr-data-pvc

--- a/apps/base/homarr/kustomization.yaml
+++ b/apps/base/homarr/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - namespace.yaml
+  - storage.yaml
+  - service.yaml

--- a/apps/base/homarr/namespace.yaml
+++ b/apps/base/homarr/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homarr

--- a/apps/base/homarr/service.yaml
+++ b/apps/base/homarr/service.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homarr
+spec:
+  ports:
+    - port: 7575
+  selector:
+    app: homarr
+  type: ClusterIP

--- a/apps/base/homarr/storage.yaml
+++ b/apps/base/homarr/storage.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homarr-data-pvc
+  namespace: homarr
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/staging/homarr/homarr-secrets.yaml
+++ b/apps/staging/homarr/homarr-secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: homarr-secrets
+stringData:
+    SECRET_ENCRYPTION_KEY: ENC[AES256_GCM,data:/39GU4w3iWVS4CxbNJQY9yvj4YHKdI0sjiDCp9HYfE6RVNQ3L10UN2oJRGDTlh0WxQVQ9VFUwRGfBbXrDRHa1A==,iv:6Naq2GryG4o9Cxv7O6kwNp52Z3UtoYiUe0NpVrAEoiM=,tag:qUoNrezUhGyQ6IzJefiDHA==,type:str]
+sops:
+    age:
+        - recipient: age1jnfhet7cj900tg9f0dwgqktjwux4km4hen8gnevpujm5260sayesujm92y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNSTRxdDQxYTBNWVhPdHBl
+            YzBodGFXWjVHVXRRTDdDS1pQa21pa1NQdlQ4Cnl0Ync1VWUrV0RiNCtsRXZxc2c3
+            VHVKYmZkSHNCNm5SdjNsemdGd2s2dEUKLS0tIEZnaHdaU1hna1d0d1pURkpBaEtJ
+            QlhYTzhybnBYOTROeU5UY3VaR3FwQ0UKe5YYTpOuFi9NP7fPXuZrhd41+QeSM19w
+            fpBchwFr0wMR8bMMRcI5sJ+aAo8lmUNEfh2MJb9n2gnxbCx2iexyuA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-17T08:54:51Z"
+    mac: ENC[AES256_GCM,data:ZRnqjJMqzphSfsa0jbOLm7Ha5jk0wXmkUFRzb7QCUg93U0fPR/S7P17lzF82QDt27QyLyRP7XoRDuZh+wfIkB+cg9wbD3G3bQSAVk5n4+OutvQ9xrZwzOQP7NG4kKHBZoNfwo3EdQBpHozFeid5V4hXedObfWS2VeyGDA5kivjQ=,iv:8+819sikiM+1wvAs9LMD6sArphZVeBJ1BciXIf7Rh0I=,tag:zdhEoioQ0dnbVeAHjdpgnQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/staging/homarr/ingress.yaml
+++ b/apps/staging/homarr/ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homarr
+spec:
+  ingressClassName: traefik
+  rules:
+    # to be accessed from LAN/VPN only - DNS in CF pointing to local IP
+    - host: homarr.milanoid.net # subdomain of my cloudflare domain
+      http:
+        paths:
+          - backend:
+              service:
+                name: homarr
+                port:
+                  number: 7575
+            path: /
+            pathType: Prefix

--- a/apps/staging/homarr/kustomization.yaml
+++ b/apps/staging/homarr/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homarr
+resources:
+  - ../../base/homarr
+  - homarr-secrets.yaml
+  - ingress.yaml

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - bazarr
   - sonarr
   - pihole
+  - homarr


### PR DESCRIPTION
## Summary
- Deploy [Homarr](https://homarr.dev/) self-hosted dashboard at `homarr.milanoid.net` via Traefik (LAN/VPN only — no Cloudflare tunnel).
- Pod pinned to `hpmini02` so the local-path PV stays with the workload; `/appdata` holds a SQLite DB and NFS is unsafe for SQLite locking.
- Resources (`100m`/`512Mi` → `1000m`/`1Gi`) and 2Gi PVC sized per Homarr's documented minimums. `SECRET_ENCRYPTION_KEY` stored via SOPS.

## Test plan
- [ ] After merge: `flux reconcile kustomization apps --with-source`
- [ ] `kubectl -n homarr get pods,svc,ingress,pvc` — all Ready/Bound
- [ ] `kubectl -n homarr logs deploy/homarr` — no fatal errors
- [ ] Visit `https://homarr.milanoid.net` from LAN/VPN → onboarding screen loads
- [ ] Complete first-run admin user creation
- [ ] `kubectl -n homarr rollout restart deploy/homarr` — settings/user persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)