### PR TITLE
fix(homarr): pin to multi-arch manifest digest

### DIFF
--- a/apps/base/homarr/deployment.yaml
+++ b/apps/base/homarr/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         kubernetes.io/hostname: hpmini02  # pinned: local-path PV lives on this node
       containers:
         - name: homarr
-          image: ghcr.io/homarr-labs/homarr:v1.59.1@sha256:655b4503c8c088873c6c4ed3e7e2e10052ff8a7199b41cdd5bac1bd21596613b
+          image: ghcr.io/homarr-labs/homarr:v1.59.1@sha256:7e6ea6949a6efd9207ddcbcf1208f40adfc98eabe7afbc6f7a3dc77426ac01bd
           ports:
             - containerPort: 7575
           envFrom:


### PR DESCRIPTION
## Summary
- The digest shipped in #203 was the arm64 sub-manifest (accidentally pulled from an Apple Silicon workstation), causing `exec format error` on the amd64 cluster nodes.
- Replace with the OCI index digest `sha256:7e6ea6949a6efd9207ddcbcf1208f40adfc98eabe7afbc6f7a3dc77426ac01bd` so containerd picks the right architecture.

## Test plan
- [ ] After merge, `flux reconcile kustomization apps --with-source`
- [ ] `kubectl -n homarr get pod` → Running
- [ ] `kubectl -n homarr logs deploy/homarr` → startup logs (not `exec format error`)
- [ ] Browse `https://homarr.milanoid.net` → onboarding screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)