### PR TITLE
fix(pihole): explicitly define default 5m Helm upgrade timeout

### DIFF
--- a/apps/base/pihole/helmrelease.yaml
+++ b/apps/base/pihole/helmrelease.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: pihole
 spec:
   interval: 30m
+  timeout: 5m
   chart:
     spec:
       chart: pihole


### PR DESCRIPTION
## Summary

- Adds `timeout: 5m` to the pihole HelmRelease spec to make the default explicit

## Context

The HelmRelease previously had no `timeout` set, relying on the Flux default of 5 minutes. A Helm upgrade on 2026-04-03 timed out at exactly 5m, leaving the HelmRelease in a `failed` state (the pod itself continued running fine on the previously deployed version). This change makes the timeout explicit so the intended behaviour is clear in code.

## Test plan

- [ ] Flux reconciles the HelmRelease successfully after merge
- [ ] `flux get helmreleases -n pihole` shows `Ready: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)