### PR TITLE
feat(grafana): add Homelab dashboards

### DIFF
--- a/monitoring/controllers/base/kube-prometheus-stack/release.yaml
+++ b/monitoring/controllers/base/kube-prometheus-stack/release.yaml
@@ -42,3 +42,30 @@ spec:
           - secretName: grafana-tls-secret
             hosts:
               - grafana.milanoid.net
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: default
+              orgId: 1
+              folder: Homelab
+              type: file
+              disableDeletion: false
+              options:
+                path: /var/lib/grafana/dashboards/default
+      dashboards:
+        default:
+          node-exporter-full:
+            gnetId: 1860
+            revision: 37
+            datasource: Prometheus
+          kubernetes-cluster:
+            gnetId: 7249
+            revision: 1
+            datasource: Prometheus
+          flux-cluster:
+            url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
+            datasource: Prometheus
+          flux-control-plane:
+            url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
+            datasource: Prometheus


### PR DESCRIPTION
## Summary

- Adds `dashboardProviders` to create a **Homelab** folder in Grafana
- Adds 4 dashboards via HelmRelease values (no ConfigMaps needed):
  - **Node Exporter Full** (grafana.com #1860) — per-node CPU/RAM/disk/network for all 3 nodes
  - **Kubernetes Cluster Monitoring** (grafana.com #7249) — pods, namespaces, resource requests/limits
  - **Flux Cluster Stats** (flux2-monitoring-example) — Kustomization/HelmRelease reconciliation status
  - **Flux Control Plane** (flux2-monitoring-example) — Flux controller health and error rates

All metrics already exist in kube-prometheus-stack — no extra exporters or ServiceMonitors needed.

## Test plan

- [ ] Flux reconciles `kube-prometheus-stack` HelmRelease (or force: `flux reconcile helmrelease kube-prometheus-stack -n monitoring`)
- [ ] Check init container logs: `kubectl logs -n monitoring deploy/kube-prometheus-stack-grafana -c download-dashboards`
- [ ] Browse to https://grafana.milanoid.net → Dashboards → Homelab — all 4 dashboards visible
- [ ] Node Exporter Full shows data for hpmini01, hpmini02 (and hpmini03 if powered on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)