### PR TITLE
fix(renovate): increase memory limit to 1Gi to prevent OOMKill

### DIFF
--- a/infrastructure/controllers/base/renovate/cronjob.yaml
+++ b/infrastructure/controllers/base/renovate/cronjob.yaml
@@ -56,10 +56,10 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 512Mi
                 limits:
                   cpu: "1"
-                  memory: 512Mi
+                  memory: 1Gi
 
           volumes:
             - name: shared


### PR DESCRIPTION
## Summary

- Pod `renovate-29613960-lbqjz` was OOMKilled after ~4 minutes on 2026-04-22 with a 512Mi limit
- Renovate hit the limit while installing the Flux CLI binary (via containerbase) and processing multiple branches concurrently
- The Job retried and succeeded, but this is wasteful and adds ~10 min of delay each time it happens

## Changes

| Setting | Before | After |
|---|---|---|
| `requests.memory` | 256Mi | 512Mi |
| `limits.memory` | 512Mi | 1Gi |

## Test plan

- [ ] Next daily Renovate run completes without OOMKill
- [ ] `kubectl get pods -n renovate` shows `Completed` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)