### PR TITLE
fix: pin k3s-upgrade image to correct version tag v1.34.3-k3s1

### DIFF
--- a/infrastructure/k3s-upgrade-plans/plans.yaml
+++ b/infrastructure/k3s-upgrade-plans/plans.yaml
@@ -13,7 +13,7 @@ spec:
         operator: Exists
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade@sha256:be278597a6d115ec5ed900f9e6866ad51522c3ced2cf6b80def9c3abf0d774bc
+    image: rancher/k3s-upgrade:v1.34.3-k3s1@sha256:c5049f95e91246cfdd4f24b496f1478bb6a9e8f734a2d157beb1e930018d7594
   version: v1.34.3+k3s1
 ---
 apiVersion: upgrade.cattle.io/v1
@@ -32,8 +32,8 @@ spec:
     args:
       - prepare
       - server-plan
-    image: rancher/k3s-upgrade@sha256:be278597a6d115ec5ed900f9e6866ad51522c3ced2cf6b80def9c3abf0d774bc
+    image: rancher/k3s-upgrade:v1.34.3-k3s1@sha256:c5049f95e91246cfdd4f24b496f1478bb6a9e8f734a2d157beb1e930018d7594
   serviceAccountName: system-upgrade
   upgrade:
-    image: rancher/k3s-upgrade@sha256:be278597a6d115ec5ed900f9e6866ad51522c3ced2cf6b80def9c3abf0d774bc
+    image: rancher/k3s-upgrade:v1.34.3-k3s1@sha256:c5049f95e91246cfdd4f24b496f1478bb6a9e8f734a2d157beb1e930018d7594
   version: v1.34.3+k3s1


### PR DESCRIPTION
## Problem

The image reference in `plans.yaml` had no tag (`rancher/k3s-upgrade`), which Renovate treated as `:latest` when `pinDigests: true` ran. Renovate pinned the digest but dropped the tag, leaving `rancher/k3s-upgrade@sha256:xxxx`.

Since then, every digest-update PR has been chasing the `:latest` tag — which moves very frequently across K3s release lines including RCs:

| PR/Commit | Digest | Actual image inside |
|-----------|--------|---------------------|
| `d056e2f` (initial pin, Apr 22) | `11b97acd` | ⚠️ v1.35.4-rc2 |
| `d4f2b37` (Apr 24, merged) | `be27859` | ⚠️ v1.36.0-rc1 |
| PR #230 (open) | `b5196d2` | v1.35.4 stable |

The intended `v1.34.3-k3s1` image was never used.

## Impact

Nodes are unaffected — `spec.version: v1.34.3+k3s1` controls which K3s binary is installed, not the image label. However the upgrade helper scripts running were from RC images.

## Fix

Pin the image with the explicit tag matching the `version:` field. Renovate will now track digests for `v1.34.3-k3s1` only, and future K3s version bumps will correctly update both tag and `version:` together.

## Related

Closes / supersedes PR #230 (which should be closed as a `latest`-tracking artifact).