### PR TITLE
fix: add dirmngr to runner image for GPG keyserver support

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -9,6 +9,8 @@ RUN ARCH=$(dpkg --print-architecture) \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 
+# dirmngr is required by sonarqube-scan-action v8+ which verifies the
+# scanner binary signature via GPG keyserver lookups before running.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends dirmngr \
     && rm -rf /var/lib/apt/lists/*

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -8,4 +8,8 @@ RUN ARCH=$(dpkg --print-architecture) \
          "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb" \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dirmngr \
+    && rm -rf /var/lib/apt/lists/*
 USER runner


### PR DESCRIPTION
## Summary
- Installs `dirmngr` in the self-hosted runner image

## Why
`sonarqube-scan-action@v8+` introduced GPG signature verification of the scanner CLI binary. It tries to fetch the SonarSource public key from a keyserver, which requires `dirmngr` (the GnuPG key management daemon). Without it the scan step fails with:

```
gpg: error running '/usr/bin/dirmngr': probably not installed
gpg: keyserver receive failed: No dirmngr
##[error] Action failed: Failed to import SonarSource public key from all keyservers.
```

## Test plan
- [ ] Rebuild and push the runner image from this branch
- [ ] Re-run the `fizz-buzz` matrix build — `SonarQube Scan` step should complete without GPG errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)