### PR TITLE
fix: bump homelab-runner image to 7e39043 (adds dirmngr)

### DIFF
--- a/infrastructure/controllers/base/arc-runners/release.yaml
+++ b/infrastructure/controllers/base/arc-runners/release.yaml
@@ -30,14 +30,14 @@ spec:
       spec:
         initContainers:
           - name: init-dind-externals
-            image: ghcr.io/milanoid-labs/homelab-runner:8855aaf@sha256:438e7d6e43e0beb96e770ef90236f1be28505ba24cb9f97658b3ed346bd7193e
+            image: ghcr.io/milanoid-labs/homelab-runner:7e39043@sha256:4cf54a154c1554c022020463f029cf3903658821d22fe7d0def524b6cfa7fc7d
             command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
             volumeMounts:
               - name: dind-externals
                 mountPath: /home/runner/tmpDir
         containers:
           - name: runner
-            image: ghcr.io/milanoid-labs/homelab-runner:8855aaf@sha256:438e7d6e43e0beb96e770ef90236f1be28505ba24cb9f97658b3ed346bd7193e
+            image: ghcr.io/milanoid-labs/homelab-runner:7e39043@sha256:4cf54a154c1554c022020463f029cf3903658821d22fe7d0def524b6cfa7fc7d
             command: ["/home/runner/run.sh"]
             env:
               - name: DOCKER_HOST


### PR DESCRIPTION
## Summary
- Updates the ARC runner image from `8855aaf` to `7e39043` in the HelmRelease

## Why
The new image (built in #249) adds `dirmngr` to the runner, which is required by `sonarqube-scan-action@v8+` to verify the scanner binary signature via GPG keyserver lookups. Without it, the Sonar scan step fails with:

```
gpg: error running '/usr/bin/dirmngr': probably not installed
##[error] Failed to import SonarSource public key from all keyservers.
```

## Changes
`infrastructure/controllers/base/arc-runners/release.yaml` — both `initContainer` and `runner` image references updated:

| | Value |
|--|-------|
| Old | `8855aaf@sha256:438e7d6e…` |
| New | `7e39043@sha256:4cf54a15…` |

## Test plan
- [ ] Merge and let Flux reconcile the HelmRelease
- [ ] Confirm runner pod restarts with the new image
- [ ] Re-run `fizz-buzz` matrix build — `SonarQube Scan` step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)