### PR TITLE
fix(renovate): teach Renovate to version-parse hotio and linuxserver images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -52,5 +52,13 @@
       schedule: ['before 9am on monday'],
       automerge: true,
     },
+    {
+      matchPackagePatterns: ['^ghcr\\.io/hotio/'],
+      versioning: 'regex:^release-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?$',
+    },
+    {
+      matchPackageNames: ['linuxserver/qbittorrent'],
+      versioning: 'loose',
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Renovate was silently skipping sonarr, radarr, bazarr, prowlarr, and torrent-client because it couldn't parse their image tags with default semver versioning
- `ghcr.io/hotio/*` images use a `release-`-prefixed tag format (e.g. `release-4.0.16.2944`); added a regex versioning rule with an optional build group to handle both 3-part (bazarr) and 4-part (sonarr/radarr/prowlarr) tags
- `linuxserver/qbittorrent` uses a date-style tag (`20.04.1`); added `loose` versioning to handle it

## Test plan

- [ ] Merge and wait for the daily Renovate CronJob (6 AM), or trigger manually: `kubectl create job --from=cronjob/renovate renovate-manual-$(date +%s) -n renovate`
- [ ] Tail logs: `kubectl logs -n renovate -l app=renovate --tail=300 -f`
- [ ] Expect Renovate to detect packages for each hotio app and qbittorrent, and open PRs if newer versions are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)