### PR TITLE
fix(pihole): add storageClassName to PVC to match existing bound claim

### DIFF
--- a/apps/base/pihole/storage.yaml
+++ b/apps/base/pihole/storage.yaml
@@ -5,6 +5,7 @@ metadata:
   name: pihole
   namespace: pihole
 spec:
+  storageClassName: local-path
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
## Summary

- Adds `storageClassName: local-path` to `apps/base/pihole/storage.yaml`
- Fixes Flux reconciliation failure introduced by #234

## Problem

After #234 merged, Flux reported:

```
PersistentVolumeClaim "pihole" is invalid: spec: Forbidden: spec is immutable after creation
- "StorageClassName": "local-path"
+ "StorageClassName": null
```

The new `storage.yaml` omitted `storageClassName`, so Flux's dry-run tried to set it to `null` on the already-bound PVC — an immutable field change. Adding `local-path` makes the declared spec match what's already on the cluster (no-op).

## Test plan

- [ ] `flux get kustomizations` — `apps` shows `Ready: True` after reconciliation
- [ ] `kubectl get pvc -n pihole` — PVC still `Bound` to same PV

🤖 Generated with [Claude Code](https://claude.com/claude-code)