### PR TITLE
fix(pihole): pin PVC volumeName to existing bound PV

### DIFF
--- a/apps/base/pihole/storage.yaml
+++ b/apps/base/pihole/storage.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: pihole
 spec:
   storageClassName: local-path
+  volumeName: pvc-34bc9bac-77b1-4421-88fe-d32a5feaf3a4
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/base/pihole/storage.yaml
+++ b/apps/base/pihole/storage.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: pihole
 spec:
   storageClassName: local-path
+  # Pinned to preserve existing data. To find the current value: kubectl get pvc pihole -n pihole -o jsonpath='{.spec.volumeName}'
   volumeName: pvc-34bc9bac-77b1-4421-88fe-d32a5feaf3a4
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary

- Adds `volumeName: pvc-34bc9bac-77b1-4421-88fe-d32a5feaf3a4` to `apps/base/pihole/storage.yaml`
- Second follow-up fix to #234 after #258

## Problem

After #258 fixed `storageClassName`, Flux still rejects the PVC:

```
- "VolumeName": "pvc-34bc9bac-77b1-4421-88fe-d32a5feaf3a4"
+ "VolumeName": ""
```

`volumeName` is immutable on a bound PVC. The manifest needs to declare it explicitly so Flux's dry-run sees a no-op instead of a forbidden mutation.

## Test plan

- [ ] `flux get kustomizations` — `apps` shows `Ready: True`
- [ ] `kubectl get pvc -n pihole` — still `Bound` to same PV

🤖 Generated with [Claude Code](https://claude.com/claude-code)