### PR TITLE
Update DNS upstreams in deployment.yaml

### DIFF
--- a/apps/base/pihole/deployment.yaml
+++ b/apps/base/pihole/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: TZ
               value: Europe/Prague
             - name: FTLCONF_dns_upstreams
-              value: "tls://1.1.1.1;tls://1.0.0.1"
+              value: "1.1.1.1;1.0.0.1"
             - name: WEBPASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Replaces `tls://1.1.1.1;tls://1.0.0.1` with `1.1.1.1;1.0.0.1` in `FTLCONF_dns_upstreams`
- dnsmasq does not understand the `tls://` URI scheme and treats `tls://1.1.1.1` as a hostname to resolve, producing a `CRIT: Name does not resolve` error at startup and causing the "DNS server failure" status in the Pi-hole dashboard
- Plain Cloudflare IPs restore normal DNS resolution; after reconciling, run `pihole -g` to populate the gravity blocklist (currently showing 0 domains)

## Test plan

- [ ] Flux reconciles and pod restarts without CRIT in logs
- [ ] Pi-hole dashboard shows green status (no DNS server failure)
- [ ] DNS queries resolve through Pi-hole
- [ ] Run `pihole -g` to populate gravity

🤖 Generated with [Claude Code](https://claude.com/claude-code)