### PR TITLE
fix(pihole): set listeningMode ALL to answer cross-subnet queries

### DIFF
--- a/apps/base/pihole/deployment.yaml
+++ b/apps/base/pihole/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: Europe/Prague
             - name: FTLCONF_dns_upstreams
               value: "1.1.1.1;1.0.0.1"
+            - name: FTLCONF_dns_listeningMode
+              value: "ALL"
             - name: WEBPASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Adds `FTLCONF_dns_listeningMode=ALL` to the Pi-hole deployment
- With the default `LOCAL` mode, dnsmasq writes `local-service` into its config, which silently drops DNS queries from subnets it's not directly attached to
- In Kubernetes, pods/nodes on hpmini01 (`10.42.0.x`) query Pi-hole running on hpmini02 (`10.42.1.x`) via flannel — these are cross-subnet queries that were being silently dropped
- Result: `dig @<pihole-ip>` from hpmini01 timed out, causing image pull failures and the "DNS server failure" status in the Pi-hole dashboard

## Root cause chain

1. `listeningMode = LOCAL` → dnsmasq adds `local-service`
2. K3s uses `/run/systemd/resolve/resolv.conf` (raw upstreams, not the systemd-resolved stub) for kubelet/containerd
3. Cross-subnet DNS queries from hpmini01 hit Pi-hole → silently dropped → timeout
4. Go's DNS resolver does not fall back to next nameserver on timeout before giving up → image pulls fail

## Test plan

- [ ] Pod restarts and Pi-hole dashboard shows green status
- [ ] `dig registry-1.docker.io @<pihole-ip>` resolves successfully from hpmini01
- [ ] Renovate cronjob image pull succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)