### PR TITLE
fix(k3s): set upgrade target version to v1.35.4+k3s1

### DIFF
--- a/infrastructure/k3s-upgrade-plans/plans.yaml
+++ b/infrastructure/k3s-upgrade-plans/plans.yaml
@@ -14,7 +14,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade:v1.35.4-k3s1@sha256:b5196d2799af4baa8aefb1653f2828b9145b53eb21d8508cec04f307eab3e11f
-  version: v1.34.3+k3s1
+  version: v1.35.4+k3s1
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
@@ -36,4 +36,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade:v1.35.4-k3s1@sha256:b5196d2799af4baa8aefb1653f2828b9145b53eb21d8508cec04f307eab3e11f
-  version: v1.34.3+k3s1
+  version: v1.35.4+k3s1


### PR DESCRIPTION
## Summary

- The `spec.version` field in `infrastructure/k3s-upgrade-plans/plans.yaml` was never updated from `v1.34.3+k3s1` (the current running version), so system-upgrade-controller never triggered any upgrade
- The upgrade image was already pinned to `v1.35.4-k3s1` but the target version was mismatched — this PR fixes the `version` field to `v1.35.4+k3s1` on both `server-plan` and `agent-plan`
- This is step 1 of 2; after nodes are confirmed on v1.35.4, PR #238 will be updated to also set `version: v1.36.1+k3s1` for the second hop

## Test plan

- [x] Merge this PR
- [x] Flux reconciles `k3s-upgrade-plans` kustomization (within 1 min)
- [x] `kubectl get plans -n system-upgrade` shows Plans running
- [x] `kubectl get nodes` confirms all nodes upgraded to `v1.35.4+k3s1`
- [ ] Then proceed with v1.36.1 upgrade via PR #238 (with version field also updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)