### PR TITLE
Scan devops-study-app in the Renovate cronjob

### DIFF
--- a/infrastructure/controllers/base/renovate/cronjob.yaml
+++ b/infrastructure/controllers/base/renovate/cronjob.yaml
@@ -44,7 +44,7 @@ spec:
               image: renovate/renovate:43.217.1@sha256:1d2ef5146c66adbf3221f0e5b361665ae636f4261349d3119fd6c3d3331b5a50
               command: ["/bin/sh", "-c"]
               args:
-                - export RENOVATE_TOKEN=$(cat /shared/token) && renovate milanoid-labs/homelab-cluster
+                - export RENOVATE_TOKEN=$(cat /shared/token) && renovate milanoid-labs/homelab-cluster milanoid-labs/devops-study-app
 
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
## Summary
- The self-hosted Renovate CronJob (\`infrastructure/controllers/base/renovate/cronjob.yaml\`) hardcodes the list of repos to scan as a CLI arg (\`RENOVATE_AUTODISCOVER\` is \`false\`). It currently only scans \`milanoid-labs/homelab-cluster\`.
- Adds \`milanoid-labs/devops-study-app\` to that arg so the daily run (schedule \`0 6 * * *\`) also scans it, now that the App has been granted access via milanoid-labs/milanoid-labs-terraform#14 and a \`renovate.json5\` config exists via milanoid-labs/devops-study-app#32.
- Flux reconciles this cluster from \`main\`, so no manual apply is needed once merged.

Part of milanoid-labs/devops-study-app#9.

## Test plan
- [ ] After merge, confirm the next CronJob run (06:00) includes \`milanoid-labs/devops-study-app\` in its logs and opens PRs there if updates exist.