### PR TITLE
fix(renovate): wire RENOVATE_HOST_RULES secret into cronjob

### DIFF
--- a/infrastructure/controllers/base/renovate/cronjob.yaml
+++ b/infrastructure/controllers/base/renovate/cronjob.yaml
@@ -49,6 +49,12 @@ spec:
               envFrom:
                 - configMapRef:
                     name: renovate-configmap
+              env:
+                - name: RENOVATE_HOST_RULES
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-container-env
+                      key: RENOVATE_HOST_RULES
               volumeMounts:
                 - name: shared
                   mountPath: /shared

--- a/infrastructure/controllers/base/renovate/cronjob.yaml
+++ b/infrastructure/controllers/base/renovate/cronjob.yaml
@@ -53,7 +53,7 @@ spec:
                 - name: RENOVATE_HOST_RULES
                   valueFrom:
                     secretKeyRef:
-                      name: renovate-container-env
+                      name: renovate-nexus-env
                       key: RENOVATE_HOST_RULES
               volumeMounts:
                 - name: shared

--- a/infrastructure/controllers/base/renovate/kustomization.yaml
+++ b/infrastructure/controllers/base/renovate/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - configmap.yaml
   - cronjob.yaml
   - renovate-container-env.yaml
+  - renovate-nexus-env.yaml
   - mint-token-script.yaml

--- a/infrastructure/controllers/base/renovate/renovate-nexus-env.yaml
+++ b/infrastructure/controllers/base/renovate/renovate-nexus-env.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: renovate-nexus-env
+    namespace: renovate
+stringData:
+    RENOVATE_HOST_RULES: ENC[AES256_GCM,data:WprlMXeMb5KoAHjxPklEiFktJ3ffvet/63SSDdpwc4hjXy/A3Kfn+CHYgKj+hcTs244dyf04azwcV0KE1yGldv/AhSYcHtYFvAbrD9eoPx5kHpZAMF6DasRkgLcP++AvvnGOLwZFt+n1NbmZAzMcYsI=,iv:1N+lWDBiQEOwZoQ3iY3BU+5tX4BoTxyYVZLpL9ZttLs=,tag:tOq7OFGDOgaeK2R4Sg95mA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzdkptYUYrTTl2MUcwQjYx
+            eUZrWnJYNzZvS1M0Y1RHK2R0SzV1dkxXNzBBCm5XWXpsV1AvbDdkTW1sVGd1VUNu
+            cTlLOXl5S0NmazBJeURCalNaV0ZDV1kKLS0tIFl3anNVOThaNnZnVnFlQkNIMC9u
+            Vkp1SFhIZGdISkFCeFBTdFc4OEE3Y00KombL4shzxEChxIqp3rHONz9e67uhKwnz
+            yHqt+l78Ay9w9iC4/tWd8TJLQY4gdIQpCYv2oRmCoFMJPSF0lzws3Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1jnfhet7cj900tg9f0dwgqktjwux4km4hen8gnevpujm5260sayesujm92y
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-19T16:50:48Z"
+    mac: ENC[AES256_GCM,data:3JMj2FQuZ3Zm+2t+I/2Itni0GF1p1x1Ya10O36Ht8Twwf0yZSTjCtR8ni2SHWX6MdlrpevhmW0t57N1TCLQpuLWDigbHnes6lZvCwNESYAJxB9sCF2X64NZ0iM1qUhKXASMNM0mHKRdKb9ISfwxyPz7tYebw+5pGkjZHZGe3qH0=,iv:sEhemFjgyBqDpwYPI5O51u202ADNMo1PpWOUX2/U7pM=,tag:feNiqEOgmYAHRqtAl73pqA==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Summary
- Adds `RENOVATE_HOST_RULES` env var to the `renovate` container, sourced from a new SOPS-encrypted Secret (`renovate-nexus-env`), wired via `secretKeyRef`.
- Fixes 401s on Nexus pypi-group lookups for `devops-study-app` by giving Renovate a place to read host credentials from.
- The credentials live in a separate secret from `renovate-container-env` (which holds `GITHUB_APP_KEY`) because editing that file in place would have required decrypting it locally, which wasn't possible without the age private key. Creating a new file only required the public age recipient already configured in `.sops.yaml`.

Fixes #329

## Test plan
- [x] `RENOVATE_HOST_RULES` added to `renovate-nexus-env` with real Nexus credentials
- [ ] Let Flux reconcile, then run a manual test job: `kubectl create job --from=cronjob/renovate -n renovate renovate-manual-test-2`
- [ ] Confirm pypi lookups in logs no longer return 401
- [ ] Clean up test job