### PR TITLE
feat(argo-workflows): declarative ServiceAccount for UI login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,15 @@ jobs:
             monitoring/configs/staging \
             persistent-volumes/staging; do
             echo "--- Validating $overlay ---"
-            kustomize build --load-restrictor LoadRestrictionsNone "$overlay" | kubeconform \
+            # kubeconform mis-splits very large multi-doc YAML (e.g. Argo Workflows CRDs)
+            # when reading from stdin, so build to a temp file and pass that instead.
+            build_file="$(mktemp /tmp/build-XXXXXX.yaml)"
+            kustomize build --load-restrictor LoadRestrictionsNone "$overlay" > "$build_file"
+            kubeconform \
               --ignore-missing-schemas \
               --kubernetes-version 1.34.0 \
-              --summary
+              --summary \
+              "$build_file"
           done
 
   kube-linter:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
       - name: Validate kustomize overlays
         run: |
           set -euo pipefail
+          build_file="$(mktemp /tmp/build-XXXXXX.yaml)"
+          trap 'rm -f "$build_file"' EXIT
           for overlay in \
             apps/staging \
             infrastructure/controllers/staging \
@@ -45,7 +47,6 @@ jobs:
             echo "--- Validating $overlay ---"
             # kubeconform mis-splits very large multi-doc YAML (e.g. Argo Workflows CRDs)
             # when reading from stdin, so build to a temp file and pass that instead.
-            build_file="$(mktemp /tmp/build-XXXXXX.yaml)"
             kustomize build --load-restrictor LoadRestrictionsNone "$overlay" > "$build_file"
             kubeconform \
               --ignore-missing-schemas \

--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # the // separates the repo root from the path inside it, per kustomize's git-URL convention
   - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=v4.0.6
 images:
   - name: quay.io/argoproj/workflow-controller

--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - ui-serviceaccount.yaml
+  - ui-rolebinding.yaml
+  - ui-token-secret.yaml
   # the // separates the repo root from the path inside it, per kustomize's git-URL convention
   # pinned to the commit for tag v4.0.6 (tags are mutable refs, commits aren't)
   - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=277e9cef0ad16d7eaaab253573d0695951a65dbd

--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   # the // separates the repo root from the path inside it, per kustomize's git-URL convention
   # pinned to the commit for tag v4.0.6 (tags are mutable refs, commits aren't)
   - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=277e9cef0ad16d7eaaab253573d0695951a65dbd

--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=v4.0.6
+images:
+  - name: quay.io/argoproj/workflow-controller
+    newTag: v4.0.6
+    digest: sha256:229337fd6c08f508991dd4e11bed527d311ae29b8631ac7a6565e179faf4764b
+  - name: quay.io/argoproj/argocli
+    newTag: v4.0.6
+    digest: sha256:516dd59b6c73c94f17c3fca306db28788c8caf0be3304f38d84293b193862c2f

--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # the // separates the repo root from the path inside it, per kustomize's git-URL convention
-  - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=v4.0.6
+  # pinned to the commit for tag v4.0.6 (tags are mutable refs, commits aren't)
+  - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=277e9cef0ad16d7eaaab253573d0695951a65dbd
 images:
   - name: quay.io/argoproj/workflow-controller
     newTag: v4.0.6

--- a/infrastructure/controllers/base/argo-workflows/namespace.yaml
+++ b/infrastructure/controllers/base/argo-workflows/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-rolebinding.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-rolebinding.yaml
@@ -1,0 +1,17 @@
+---
+# RoleBinding (not ClusterRoleBinding) so the "admin" aggregated role -
+# which includes the workflow permissions cluster-install aggregates into
+# it - only applies within the argo namespace, not cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-ui-admin
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argo-ui
+    namespace: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-serviceaccount.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-ui
+  namespace: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-token-secret.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-token-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-ui-token
+  namespace: argo
+  annotations:
+    kubernetes.io/service-account.name: argo-ui
+type: kubernetes.io/service-account-token

--- a/infrastructure/controllers/staging/argo-workflows/ingress.yaml
+++ b/infrastructure/controllers/staging/argo-workflows/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argo-server
+spec:
+  ingressClassName: traefik
+  rules:
+    # to be accessed from LAN/VPN only - DNS in CF pointing to local IP
+    - host: argo.milanoid.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: argo-server
+                port:
+                  number: 2746
+            path: /
+            pathType: Prefix

--- a/infrastructure/controllers/staging/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/staging/argo-workflows/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo
+resources:
+  - ../../base/argo-workflows
+  - ingress.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: argo-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --secure=false
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/httpGet/scheme
+        value: HTTP

--- a/infrastructure/controllers/staging/kustomization.yaml
+++ b/infrastructure/controllers/staging/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - arc-controller
   - arc-runners
   - argocd
+  - argo-workflows
   - system-upgrade-controller


### PR DESCRIPTION
## Summary
- Follow-up to #339. Replaces the manual `kubectl create token` workaround for logging into the Argo Workflows UI with declarative GitOps resources, same pattern as `apps/base/headlamp`:
  - `ServiceAccount` `argo-ui` in the `argo` namespace
  - `RoleBinding` (namespace-scoped, not cluster-wide) binding it to the built-in `admin` ClusterRole — `cluster-install` already aggregates workflow permissions into `admin`/`edit`/`view` via labels, so this grants workflow management within the `argo` namespace only, not cluster-admin
  - A long-lived `Secret` of type `kubernetes.io/service-account-token` (Kubernetes' token controller populates it automatically)
- No manual `kubectl` steps needed anymore to get a UI login token.

## Test plan
- [x] `kustomize build infrastructure/controllers/staging/argo-workflows` resolves cleanly
- [x] `kubeconform` (v0.6.7, matching CI) reports 0 errors against the full `infrastructure/controllers/staging` overlay
- [ ] After merge: `kubectl -n argo get secret argo-ui-token -o jsonpath='{.data.token}' | base64 -d` to get the token, paste `Bearer <token>` into the Argo UI login box, confirm access