### PR TITLE
feat(argo-workflows): declarative ServiceAccount for UI login

### DIFF
--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - ui-serviceaccount.yaml
+  - ui-rolebinding.yaml
+  - ui-token-secret.yaml
   # the // separates the repo root from the path inside it, per kustomize's git-URL convention
   # pinned to the commit for tag v4.0.6 (tags are mutable refs, commits aren't)
   - github.com/argoproj/argo-workflows//manifests/cluster-install?ref=277e9cef0ad16d7eaaab253573d0695951a65dbd

--- a/infrastructure/controllers/base/argo-workflows/ui-rolebinding.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-rolebinding.yaml
@@ -1,0 +1,17 @@
+---
+# RoleBinding (not ClusterRoleBinding) so the "admin" aggregated role -
+# which includes the workflow permissions cluster-install aggregates into
+# it - only applies within the argo namespace, not cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-ui-admin
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argo-ui
+    namespace: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-serviceaccount.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-ui
+  namespace: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-token-secret.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-token-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-ui-token
+  namespace: argo
+  annotations:
+    kubernetes.io/service-account.name: argo-ui
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
## Summary
- Follow-up to #339. Replaces the manual `kubectl create token` workaround for logging into the Argo Workflows UI with declarative GitOps resources, same pattern as `apps/base/headlamp`:
  - `ServiceAccount` `argo-ui` in the `argo` namespace
  - `RoleBinding` (namespace-scoped, not cluster-wide) binding it to the built-in `admin` ClusterRole — `cluster-install` already aggregates workflow permissions into `admin`/`edit`/`view` via labels, so this grants workflow management within the `argo` namespace only, not cluster-admin
  - A long-lived `Secret` of type `kubernetes.io/service-account-token` (Kubernetes' token controller populates it automatically)
- No manual `kubectl` steps needed anymore to get a UI login token.

## Test plan
- [x] `kustomize build infrastructure/controllers/staging/argo-workflows` resolves cleanly
- [x] Single commit, rebased cleanly onto current `main` (replaces #340, which had stale commits from the already-merged #339)
- [ ] After merge: `kubectl -n argo get secret argo-ui-token -o jsonpath='{.data.token}' | base64 -d` to get the token, paste `Bearer <token>` into the Argo UI login box, confirm access