### PR TITLE
fix(argo-workflows): grant argo-ui cluster-wide view access

### DIFF
--- a/infrastructure/controllers/base/argo-workflows/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-workflows/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - namespace.yaml
   - ui-serviceaccount.yaml
   - ui-rolebinding.yaml
+  - ui-clusterrolebinding.yaml
   - ui-token-secret.yaml
   # the // separates the repo root from the path inside it, per kustomize's git-URL convention
   # pinned to the commit for tag v4.0.6 (tags are mutable refs, commits aren't)

--- a/infrastructure/controllers/base/argo-workflows/ui-clusterrolebinding.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+# cluster-wide read access so the UI's default "all namespaces" workflow
+# list works; write/admin actions stay scoped to the argo namespace via
+# ui-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-ui-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: argo-ui
+    namespace: argo

--- a/infrastructure/controllers/base/argo-workflows/ui-clusterrolebinding.yaml
+++ b/infrastructure/controllers/base/argo-workflows/ui-clusterrolebinding.yaml
@@ -1,7 +1,9 @@
 ---
 # cluster-wide read access so the UI's default "all namespaces" workflow
 # list works; write/admin actions stay scoped to the argo namespace via
-# ui-rolebinding.yaml
+# ui-rolebinding.yaml. argo-aggregate-to-view (shipped by cluster-install)
+# is scoped to just the argoproj.io CRDs, unlike the built-in "view" role
+# which would also grant read on Pods/ConfigMaps/Services etc. everywhere.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: argo-aggregate-to-view
 subjects:
   - kind: ServiceAccount
     name: argo-ui


### PR DESCRIPTION
## Summary
- Logging into the Argo Workflows UI was broken: the `argo-ui` ServiceAccount only had `admin` rights scoped to the `argo` namespace (#341), but the UI's default landing page calls `GET /api/v1/workflows/` (no namespace = all namespaces), which 403'd and bounced back to the login screen.
- Adds a `ClusterRoleBinding` to the built-in `view` ClusterRole for cluster-wide read access. Write/delete/retry actions stay scoped to the `argo` namespace via the existing RoleBinding from #341 — not a blanket cluster-admin grant.

## Test plan
- [x] Applied the ClusterRoleBinding directly to the live cluster and confirmed `GET /api/v1/workflows/` with the `argo-ui` token flips from `403` to `200`
- [x] `kustomize build infrastructure/controllers/staging/argo-workflows` resolves cleanly
- [ ] After merge: log into the UI again with the existing token (`kubectl -n argo get secret argo-ui-token -o jsonpath='{.data.token}' | base64 -d`) and confirm it no longer bounces back to login