### PR TITLE
fix(disk-usage-report): use spec.schedules, not removed spec.schedule

### DIFF
--- a/workflows/base/disk-usage-report/cronworkflow.yaml
+++ b/workflows/base/disk-usage-report/cronworkflow.yaml
@@ -4,7 +4,8 @@ kind: CronWorkflow
 metadata:
   name: media-disk-usage-report
 spec:
-  schedule: "0 6 * * *"
+  schedules:
+    - "0 6 * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- Follow-up to #343. After merge, Flux's `workflows` Kustomization failed reconciliation: `CronWorkflow/downloaders/media-disk-usage-report dry-run failed ... .spec.schedule: field not declared in schema`.
- The `CronWorkflow` CRD shipped by cluster-install `v4.0.6` only has `spec.schedules` (a list) — the singular `spec.schedule` field was removed in v4. Switches to `spec.schedules: ["0 6 * * *"]`.

## Test plan
- [x] `kubectl apply -f - --dry-run=server` against the live cluster's installed CRD succeeds (was failing before this fix)
- [x] `kustomize build workflows/staging` resolves cleanly