### PR TITLE
fix(disk-usage-report): grant disk-usage-report executor RBAC

### DIFF
--- a/workflows/base/disk-usage-report/cronworkflow.yaml
+++ b/workflows/base/disk-usage-report/cronworkflow.yaml
@@ -12,6 +12,7 @@ spec:
   failedJobsHistoryLimit: 3
   workflowSpec:
     entrypoint: report
+    serviceAccountName: disk-usage-report
     ttlStrategy:
       secondsAfterCompletion: 3600
     templates:

--- a/workflows/staging/disk-usage-report/executor-rbac.yaml
+++ b/workflows/staging/disk-usage-report/executor-rbac.yaml
@@ -1,0 +1,27 @@
+---
+# minimal RBAC the default ServiceAccount in this namespace needs to act as
+# a workflow executor - https://argo-workflows.readthedocs.io/en/latest/workflow-rbac/
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow-executor
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflow-executor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflow-executor
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/workflows/staging/disk-usage-report/executor-rbac.yaml
+++ b/workflows/staging/disk-usage-report/executor-rbac.yaml
@@ -1,10 +1,17 @@
 ---
-# minimal RBAC the default ServiceAccount in this namespace needs to act as
-# a workflow executor - https://argo-workflows.readthedocs.io/en/latest/workflow-rbac/
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: disk-usage-report
+  namespace: downloaders
+---
+# minimal RBAC the workflow executor needs to act as a workflow executor
+# https://argo-workflows.readthedocs.io/en/latest/workflow-rbac/
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: workflow-executor
+  namespace: downloaders
 rules:
   - apiGroups:
       - argoproj.io
@@ -18,10 +25,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: workflow-executor
+  namespace: downloaders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: workflow-executor
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: disk-usage-report
+    namespace: downloaders

--- a/workflows/staging/disk-usage-report/kustomization.yaml
+++ b/workflows/staging/disk-usage-report/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: downloaders
 resources:
   - ../../base/disk-usage-report
+  - executor-rbac.yaml


### PR DESCRIPTION
## Summary
- The workflow was failing with: `workflowtaskresults.argoproj.io is forbidden: User "system:serviceaccount:downloaders:default" cannot create resource "workflowtaskresults" in API group "argoproj.io" in the namespace "downloaders"`.
- Workflow pods run as the `default` ServiceAccount of their own namespace unless `serviceAccountName` is explicitly set. `cluster-install` (#339) only grants the minimal executor RBAC (`workflowtaskresults` create/patch — [docs](https://argo-workflows.readthedocs.io/en/latest/workflow-rbac/)) to the `argo` namespace's own ServiceAccounts. Any other namespace running workflows — here, `downloaders` — needs the same Role/RoleBinding added for itself.
- Adds `workflows/staging/disk-usage-report/executor-rbac.yaml`: a `Role` + `RoleBinding` granting exactly that to `downloaders`' `default` ServiceAccount, scoped to this one namespace.

## Test plan
- [x] Applied live to the cluster, then re-ran the CronWorkflow with `argo -n downloaders submit --from cronworkflow/media-disk-usage-report --generate-name disk-usage-report-test-` — workflow now `Succeeded` (previously errored), logs show correct `du`/`df` output
- [x] `kustomize build workflows/staging` resolves cleanly, RoleBinding subject correctly gets `namespace: downloaders` injected by the kustomize namespace transformer
- [x] `kubeconform` (v0.6.7) — 0 errors