### PR TITLE
fix: make Renovate track spec.version in k3s upgrade plans

### DIFF
--- a/infrastructure/k3s-upgrade-plans/plans.yaml
+++ b/infrastructure/k3s-upgrade-plans/plans.yaml
@@ -14,7 +14,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade:v1.36.2-k3s1@sha256:471084010ecf1bc6e4b9544529400bf47c8da3d268e2f67fa239dacd735c0083
-  version: v1.36.1+k3s1
+  version: v1.36.2+k3s1
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
@@ -36,4 +36,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade:v1.36.2-k3s1@sha256:471084010ecf1bc6e4b9544529400bf47c8da3d268e2f67fa239dacd735c0083
-  version: v1.36.1+k3s1
+  version: v1.36.2+k3s1

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,18 @@
       registryUrlTemplate: 'https://ghcr.io',
       packageNameTemplate: 'actions/actions-runner-controller-charts/{{depName}}',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/infrastructure/k3s-upgrade-plans/plans\\.yaml/',
+      ],
+      matchStrings: [
+        'version: (?<currentValue>v[^\\n]+)',
+      ],
+      depNameTemplate: 'k3s-io/k3s',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\+k3s(?<build>\\d+)$',
+    },
   ],
   packageRules: [
     {
@@ -53,6 +65,17 @@
         'actions/actions-runner-controller-charts/**',
       ],
       pinDigests: false,
+    },
+    {
+      matchManagers: ['custom.regex'],
+      matchPackageNames: ['k3s-io/k3s'],
+      pinDigests: false,
+      groupName: 'k3s upgrade',
+    },
+    {
+      matchManagers: ['kubernetes'],
+      matchPackageNames: ['rancher/k3s-upgrade'],
+      groupName: 'k3s upgrade',
     },
     {
       matchPackageNames: [


### PR DESCRIPTION
## Summary

- Adds a `customManagers` regex rule to `renovate.json5` so Renovate also tracks the `spec.version` field in `infrastructure/k3s-upgrade-plans/plans.yaml` against `k3s-io/k3s` GitHub releases
- Groups the `spec.version` update with the `rancher/k3s-upgrade` image update via `packageRules` so both land in a single PR
- Corrects the current `plans.yaml` to target `v1.36.2+k3s1`, matching the image already merged in PR #364 (without this fix, the System Upgrade Controller was seeing no version delta and doing nothing)

## Root cause

The System Upgrade Controller compares each node's running K3s version against `spec.version` in the Plan CR. Renovate's `kubernetes` manager only tracks container images — it has no awareness of the `spec.version` field. So PR #364 updated the upgrade *tool* image but left the upgrade *target* unchanged, causing nodes to stay on v1.36.1.

## Test plan

- [ ] Merge this PR — Flux will apply the corrected `plans.yaml` and SUC should schedule upgrade jobs targeting `v1.36.2+k3s1`
- [ ] When the next k3s patch is released, confirm Renovate opens a single grouped PR bumping both `spec.upgrade.image` and `spec.version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)