### PR TITLE
Add Argo Rollouts controller

### DIFF
--- a/infrastructure/controllers/base/argo-rollouts/kustomization.yaml
+++ b/infrastructure/controllers/base/argo-rollouts/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  # pinned to the commit for tag v1.8.3 (tags are mutable refs, commits aren't)
+  - github.com/argoproj/argo-rollouts//manifests/cluster-install?ref=49fa1516cf71672b69e265267da4e1d16e1fe114
+  - https://raw.githubusercontent.com/argoproj/argo-rollouts/49fa1516cf71672b69e265267da4e1d16e1fe114/manifests/dashboard-install.yaml
+images:
+  - name: quay.io/argoproj/argo-rollouts
+    newTag: v1.8.3
+    digest: sha256:7e35af392d77eeb16488570d87a8af9e19879ae6328736172499815cc2a56c8c
+  - name: quay.io/argoproj/kubectl-argo-rollouts
+    newTag: v1.8.3
+    digest: sha256:f60f0eec76b35f7e21c10c8dd35b49c9108cd96a19e94b5056ee17765ca5ef48

--- a/infrastructure/controllers/base/argo-rollouts/namespace.yaml
+++ b/infrastructure/controllers/base/argo-rollouts/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-rollouts

--- a/infrastructure/controllers/staging/argo-rollouts/ingress.yaml
+++ b/infrastructure/controllers/staging/argo-rollouts/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argo-rollouts-dashboard
+spec:
+  ingressClassName: traefik
+  rules:
+    # to be accessed from LAN/VPN only - DNS in CF pointing to local IP
+    - host: rollouts.milanoid.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: argo-rollouts-dashboard
+                port:
+                  number: 3100
+            path: /
+            pathType: Prefix

--- a/infrastructure/controllers/staging/argo-rollouts/kustomization.yaml
+++ b/infrastructure/controllers/staging/argo-rollouts/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo-rollouts
+resources:
+  - ../../base/argo-rollouts
+  - ingress.yaml

--- a/infrastructure/controllers/staging/kustomization.yaml
+++ b/infrastructure/controllers/staging/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - arc-runners
   - argocd
   - argo-workflows
+  - argo-rollouts
   - system-upgrade-controller


### PR DESCRIPTION
## Summary
- Installs the Argo Rollouts controller (v1.8.3) via a remote Kustomize base pinned to a commit SHA, mirroring the Argo Workflows pattern rather than Helm.
- Installs the Argo Rollouts dashboard and exposes it LAN-only via Traefik ingress at `rollouts.milanoid.net`.
- Both controller and dashboard images are pinned to their linux/amd64-specific digests, consistent with repo convention for the amd64-only cluster nodes.
- Registers `argo-rollouts` in `infrastructure/controllers/staging/kustomization.yaml` alongside `argocd` and `argo-workflows`.

## Test plan
- [x] `kustomize build infrastructure/controllers/base/argo-rollouts` succeeds and images resolve to pinned digests
- [x] `kustomize build infrastructure/controllers/staging/argo-rollouts` succeeds with namespace transformer applied
- [x] `kustomize build infrastructure/controllers/staging` (full registry) still builds cleanly
- [ ] After Flux reconciles: `flux get kustomizations` shows `infrastructure-controllers` healthy
- [ ] `kubectl get pods -n argo-rollouts` shows controller + dashboard pods Running
- [ ] `kubectl get crd | grep rollouts` shows Rollout/AnalysisRun/AnalysisTemplate/Experiment CRDs
- [ ] `https://rollouts.milanoid.net` loads on LAN/VPN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWWL7cWsJ5drR6qKrUdLct