### PR TITLE
fix(devops-study-app): cap CPU/memory usage

### DIFF
--- a/apps/argocd/devops-study-app/deployment.yaml
+++ b/apps/argocd/devops-study-app/deployment.yaml
@@ -19,3 +19,10 @@ spec:
           name: devops-study-app-backend
           ports:
             - containerPort: 22112
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi


### PR DESCRIPTION
## Summary
- `devops-study-app-backend` was using 634m+ CPU with no resource limits (BestEffort QoS) — the container runs Uvicorn with `--reload`, which continuously polls the filesystem, driving up node CPU and fan noise.
- Adds `requests`/`limits` (50m/64Mi request, 200m/256Mi limit) to cap it as a stopgap.
- The real fix (removing `--reload`) needs to happen upstream in the `milanoid-labs/study-app-api` image build/entrypoint, outside this repo.

## Test plan
- [ ] Merge and let Argo CD sync the deployment
- [ ] `kubectl top pods -n devops-study-app` to confirm CPU is now capped near the limit
- [ ] Watch for OOMKilled/CPU throttling events; bump limits if the app needs more headroom
- [ ] Follow up separately to remove `--reload` from the backend image

🤖 Generated with [Claude Code](https://claude.com/claude-code)