### PR TITLE
feat(renovate): add minimumReleaseAge to delay updates on fresh releases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
     ],
   },
   pinDigests: true,
+  minimumReleaseAge: '3 days',
   customManagers: [
     {
       customType: 'regex',


### PR DESCRIPTION
## Summary
- Adds Renovate's `minimumReleaseAge: '3 days'` global setting so PRs aren't opened for releases until they've been out for 3 days, reducing risk from freshly published broken/compromised releases.

## Test plan
- [x] `renovate.json5` still valid JSON5 (visually verified structure)
- [ ] Confirm next Renovate run applies the delay to new dependency updates

Closes #432